### PR TITLE
fix: fixes for GitHub App support

### DIFF
--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -145,7 +145,10 @@ tekton:
 JenkinsXGitHub:
   username: "{{ .Parameters.pipelineUser.username }}"
   email: "{{ .Parameters.pipelineUser.email }}"
+{{- if .Requirements.githubApp.enabled }}
+{{- else }}
   password: "{{ .Parameters.pipelineUser.token }}"
+{{- end }}
 
 {{- if .Requirements.ingress.tls }}
 certmanager:

--- a/env/tekton/values.tmpl.yaml
+++ b/env/tekton/values.tmpl.yaml
@@ -9,11 +9,32 @@ enabled: false
 webhook:
   enabled: false
 
+{{- if .Requirements.githubApp.enabled }}
+image:
+  upstreamtag: v20191107-d77506e
+  kubeconfigwriter: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/kubeconfigwriter
+  credsinit: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/creds-init
+  gitinit: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/git-init
+  nop: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/nop
+  bash: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/bash
+  gsutil: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/gsutil
+  controller: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/controller
+  webhook: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/webhook
+  entrypoint: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/entrypoint
+  pullrequest: gcr.io/jenkinsxio/tektoncd/pipeline/cmd/pullrequest-init
+{{- end }}
+
 auth:
   git:
     username: "{{ .Parameters.pipelineUser.username }}"
     password: "{{ .Parameters.pipelineUser.token }}"
+{{- if .Requirements.githubApp.enabled }}
+    # lets disable using a github.com secret in knative-
+    url: "https://disabled.github.com"
+{{- else }}
     url: {{ .Requirements.cluster.gitServer | default "https://github.com" }}
+{{- end }}
+
 
 {{- if hasKey .Parameters "docker" }}
 docker:


### PR DESCRIPTION
lets use a patched tekton if using GitHub Apps for the github app secret choosing logic

also lets disable installing the github.com secrets if using GitHub Apps as we will need to generate those from the github apps tokens