### PR TITLE
fix: fix regresssion in build controller due to yaml replacement

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -129,8 +129,8 @@ PipelineSecrets:
             IdentityFile /root/.ssh-git/ssh-key
             StrictHostKeyChecking no
 
-{{- if eq .Requirements.webhook "lighthouse" }}
 controllerbuild:
+{{- if eq .Requirements.webhook "lighthouse" }}
   enabled: true
   args:
   - "controller"
@@ -139,11 +139,12 @@ controllerbuild:
   - "--batch-mode"
   - "--git-credentials"
   - "--verbose"
+{{- else }}
+  enabled: false
 {{- end }}
 
 {{- if hasKey .Requirements.cluster "gke" }}
 {{- if hasKey .Requirements.cluster.gke "projectNumber" }}
-controllerbuild:
   serviceaccount:
     annotations:
       iam.gke.io/gcp-service-account: {{ .Requirements.cluster.clusterName }}-st@{{ .Requirements.cluster.gke.projectNumber }}.iam.gserviceaccount.com


### PR DESCRIPTION
fixes the indentation of the YAML so we don't lose the lighthouse config changes