### PR TITLE
chore: avoid expose and cleanup jobs running by switching the refresh…

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,6 +36,5 @@ dependencies:
   alias: jx-segment-controller
 - name: jx-tenant-service
   alias: refresh
-  version: 0.0.155
   repository: https://storage.googleapis.com/chartmuseum.jenkins-x.io
   condition: refresh.enabled


### PR DESCRIPTION
… job to use a newer version from the version stream