### PR TITLE
fix: remove jx-tenant-service image references from boot pipeline

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -85,14 +85,12 @@ pipelineConfig:
             - token
             command: jxt
             dir: /workspace/source/env
-            image: gcr.io/jenkinsxio/jx-tenant-service:0.0.285
             name: get-tenant-token
           - args:
             - get
             - subdomain
             command: jxt
             dir: /workspace/source/env
-            image: gcr.io/jenkinsxio/jx-tenant-service:0.0.285
             name: get-subdomain
           - args:
             - step
@@ -263,7 +261,6 @@ pipelineConfig:
             - repositories
             command: jxt
             dir: /workspace/source/env
-            image: gcr.io/jenkinsxio/jx-tenant-service:0.0.285
             name: register-repositories
           - args:
             - get
@@ -271,7 +268,6 @@ pipelineConfig:
             - token
             command: jxt
             dir: /workspace/source/env
-            image: gcr.io/jenkinsxio/jx-tenant-service:0.0.285
             name: refresh-git-tokens
           - args:
             - step


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

I'm assuming that when using the interpret mode during `jx boot` that it doesn't actually use the image override in any case.