### PR TITLE
fix: Scale up Lighthouse webhook controller to two pods

### DIFF
--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -25,7 +25,7 @@ githubApp:
   username: "{{ .Parameters.pipelineUser.username }}"
 {{- end }}
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: gcr.io/jenkinsxio/lighthouse


### PR DESCRIPTION
This needs to be HA.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>